### PR TITLE
build: relax required versions of arq and prometheus-client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ keywords = ["arq", "prometheus", "metrics"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-prometheus-client = "^0.14.1"
-arq = "^0.23"
+prometheus-client = ">=0.14.1,<1.0.0"
+arq = ">0.23,<1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"


### PR DESCRIPTION
Updates `pyproject.toml` to allow `prometheus-client<1.0.0` and `arq<1.0`.

Successfully tested with latest version of both dependencies:
```
  • Updating arq (0.23 -> 0.25.0)
  • Updating prometheus-client (0.14.1 -> 0.16.0)
```

`example/arq_prometheus_worker/` also works as expected.

Solves #4 