### PR TITLE
Introduced variables REDIS_CONTAINER_NAME and REDIS_PORT

### DIFF
--- a/example/arq_prometheus_worker/scripts/init_redis
+++ b/example/arq_prometheus_worker/scripts/init_redis
@@ -1,18 +1,20 @@
 #!/bin/sh -e
 
-# if a redis container is running, print instructions to kill it and exit
+# Check if a Redis container is already running
 RUNNING_CONTAINER=$(docker ps --filter 'name=redis' --format '{{.ID}}')
 if [ -n "$RUNNING_CONTAINER" ]; then
-  echo >&2 "there is a redis container already running, kill it with"
-  echo >&2 "    docker kill ${RUNNING_CONTAINER}"
+  echo >&2 "A Redis container is already running. Please stop it before running this script."
   exit 1
 fi
 
 # Launch Redis using Docker
-docker run \
-    -p "6379:6379" \
-    -d \
-    --name "redis_$(date '+%s')" \
-    redis:6
+REDIS_CONTAINER_NAME="redis_$(date '+%s')"
+REDIS_PORT="6379"
 
->&2 echo "Redis is ready to go!"
+docker run \
+  -p "${REDIS_PORT}:${REDIS_PORT}" \
+  -d \
+  --name "${REDIS_CONTAINER_NAME}" \
+  redis:6
+
+echo "Redis container '${REDIS_CONTAINER_NAME}' is now running on port ${REDIS_PORT}."


### PR DESCRIPTION
Added more descriptive error message when a Redis container is already running.

Introduced variables REDIS_CONTAINER_NAME and REDIS_PORT for better readability and maintainability.

Adjusted the output message to indicate the name of the created Redis container and the port it's running on.